### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/bank/payments/controller/PaymentController.java

### DIFF
--- a/src/main/java/com/bank/payments/controller/PaymentController.java
+++ b/src/main/java/com/bank/payments/controller/PaymentController.java
@@ -30,7 +30,7 @@ public class PaymentController {
             @RequestBody PaymentRequest request,
             @RequestHeader("Idempotency-Key") String key) {
         String value = null;
-        if (value.equals("test")) { // Sonar bug: possible NullPointerException
+        if (value != null && value.equals("test")) {
             // do nothing
         }
         request.setIdempotencyKey(key);


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for 33c9a2114655559cbac75270ee8d7a8061b33ec4

**Description:**  
This pull request fixes a potential NullPointerException in the `PaymentController.java` file. The original code was checking if a `String` variable `value` equals `"test"` without first ensuring that `value` was not null. Since `value` was explicitly set to `null`, this would always cause a NullPointerException at runtime. The fix adds a null check before calling `.equals()`, preventing the exception.

**Summary:**  
- `src/main/java/com/bank/payments/controller/PaymentController.java` (modified)  
  The conditional statement `if (value.equals("test"))` was changed to `if (value != null && value.equals("test"))` to avoid a NullPointerException. This is a defensive programming practice to ensure that the method `.equals()` is not called on a null reference.

**Recommendation:**  
- Always perform null checks before calling methods on objects that can be null to avoid runtime exceptions.  
- Consider initializing variables with meaningful default values or refactor the logic to avoid unnecessary null assignments.  
- Review other parts of the codebase for similar patterns that might cause NullPointerExceptions.  
- If the variable `value` is not used meaningfully (as in this snippet it is set to null and only checked), consider removing or refactoring this code to improve clarity and maintainability.

**Explanation of vulnerabilities:**  
- **Vulnerability:** The original code had a NullPointerException risk because it called `.equals()` on a null object. This can cause the application to crash or behave unexpectedly.  
- **Correction:** Added a null check before calling `.equals()`:

```java
String value = null;
if (value != null && value.equals("test")) {
    // do nothing
}
```

This ensures that `.equals()` is only called if `value` is not null, preventing the exception.  
- **Suggestion:** If `value` is always null here, this condition will never be true. It might be better to review the logic to see if this check is necessary or if `value` should be assigned a meaningful value before the check.