### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/bank/payments/controller/PaymentController.java

### DIFF
--- a/src/main/java/com/bank/payments/controller/PaymentController.java
+++ b/src/main/java/com/bank/payments/controller/PaymentController.java
@@ -30,7 +30,7 @@ public class PaymentController {
             @RequestBody PaymentRequest request,
             @RequestHeader("Idempotency-Key") String key) {
         String value = null;
-        if (value.equals("test")) { // Sonar bug: possible NullPointerException
+        if (value != null && value.equals("test")) {
             // do nothing
         }
         request.setIdempotencyKey(key);


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for 7dc891eede6a37b624318b7a2d4d51ff78cb4642

**Description:**  
This pull request fixes a potential NullPointerException in the `PaymentController.java` file. The original code was calling `.equals("test")` on a variable `value` that was explicitly set to `null`, which would always throw a NullPointerException at runtime. The fix adds a null check before calling `.equals()`, ensuring the code safely handles the null case.

**Summary:**  
- `src/main/java/com/bank/payments/controller/PaymentController.java` (modified)  
  The conditional statement `if (value.equals("test"))` was changed to `if (value != null && value.equals("test"))` to prevent a NullPointerException. This is a defensive programming practice to avoid runtime exceptions when dealing with potentially null objects.

**Recommendation:**  
- Always perform null checks before calling methods on objects that can be null to avoid NullPointerExceptions.  
- Consider initializing variables with meaningful default values or refactoring code to avoid unnecessary null assignments.  
- Review other parts of the codebase for similar patterns where `.equals()` or other method calls are made on variables that might be null.  
- Since the current `if` block does nothing (`// do nothing`), evaluate if this condition is necessary or if it can be removed to clean up the code.

**Explanation of vulnerabilities:**  
- **Vulnerability:** The original code had a direct call to `value.equals("test")` where `value` was `null`. This causes a NullPointerException, which can crash the application or lead to denial of service if not handled properly.  
- **Correction:** Added a null check before calling `.equals()` to ensure safe execution:

```java
if (value != null && value.equals("test")) {
    // do nothing
}
```

This prevents the NullPointerException by ensuring `value` is not null before invoking `.equals()`.