### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/bank/payments/controller/PaymentController.java

### DIFF
--- a/src/main/java/com/bank/payments/controller/PaymentController.java
+++ b/src/main/java/com/bank/payments/controller/PaymentController.java
@@ -30,7 +30,7 @@ public class PaymentController {
             @RequestBody PaymentRequest request,
             @RequestHeader("Idempotency-Key") String key) {
         String value = null;
-        if (value.equals("test")) { // Sonar bug: possible NullPointerException
+        if ("test".equals(value)) { // Sonar bug: possible NullPointerException
             // do nothing
         }
         request.setIdempotencyKey(key);


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 785690af83978cc771e7cce6964c009e4e8a95fa

**Description:**  
This pull request fixes a potential NullPointerException in the `PaymentController.java` file. The original code was calling the `.equals()` method on a variable `value` that was explicitly set to `null`. This would cause a runtime exception if the code path was executed. The fix changes the order of the `.equals()` call to use a constant string `"test"` as the caller, which is a common defensive programming practice to avoid null pointer exceptions.

**Summary:**  
- `src/main/java/com/bank/payments/controller/PaymentController.java` (modified)  
  - Changed the conditional check from `value.equals("test")` to `"test".equals(value)` to prevent a possible NullPointerException.  
  - The variable `value` is initialized as `null`, so calling `.equals()` on it would throw an exception. By calling `.equals()` on the constant string `"test"`, the code safely compares the value without risk of null dereference.

**Recommendation:**  
- This is a good fix to prevent a NullPointerException.  
- However, the variable `value` is assigned `null` and never updated before the check, so the condition will always be false. Consider reviewing the logic to either remove this check if it is unnecessary or properly assign a meaningful value to `value` before the comparison.  
- Adding comments explaining why this check exists or what the intended behavior is would improve code readability and maintainability.  
- Ensure that the idempotency key handling logic is thoroughly tested, as it is critical for payment processing to avoid duplicate transactions.

**Explanation of vulnerabilities:**  
- The original code had a potential NullPointerException vulnerability because it called `.equals()` on a variable that could be `null`. This is a common source of runtime exceptions in Java.  
- The fix uses the constant string `"test"` as the caller of `.equals()`, which is null-safe. This pattern is recommended to avoid null pointer exceptions in string comparisons.  

Example of the fix:  
```java
String value = null;
// Original vulnerable code:
// if (value.equals("test")) { ... }

// Fixed null-safe code:
if ("test".equals(value)) {
    // do nothing
}
```

No other security vulnerabilities were identified in this change.